### PR TITLE
feat: skeleton login page

### DIFF
--- a/client/components/Box/Box.tsx
+++ b/client/components/Box/Box.tsx
@@ -2,6 +2,14 @@ import * as React from 'react';
 import MUIBox from '@mui/material/Box';
 import BoxProps from './Box.types';
 
-export default function Box({ sx, children }: BoxProps) {
-  return <MUIBox sx={sx}>{children}</MUIBox>;
+export default function Box({ sx, children, component, onSubmit }: BoxProps) {
+  return (
+    <MUIBox
+      sx={sx}
+      component={component}
+      onSubmit={onSubmit}
+    >
+      {children}
+    </MUIBox>
+  );
 }

--- a/client/components/Box/Box.types.ts
+++ b/client/components/Box/Box.types.ts
@@ -2,7 +2,14 @@ import React from 'react';
 
 export default interface BoxProps {
   /** The system prop that allows defining system overrides as well as additional CSS styles. */
-  sx: object;
+  sx?: object;
+
   /** The content of the component */
   children: React.ReactNode;
+
+  /** The component used for the root node. Either a string to use a HTML element or a component. */
+  component: React.ElementType;
+
+  /** Leave it to the developer to decide what function to assign here */
+  onSubmit?: unknown;
 }

--- a/client/components/Button/Button.tsx
+++ b/client/components/Button/Button.tsx
@@ -9,6 +9,8 @@ export default function Button({
   variant,
   fullWidth,
   disabled,
+  type,
+  sx,
 }: ButtonProps) {
   return (
     <MUIButton
@@ -16,6 +18,8 @@ export default function Button({
       variant={variant}
       fullWidth={fullWidth}
       disabled={disabled}
+      type={type}
+      sx={sx}
     >
       {label}
     </MUIButton>

--- a/client/components/Button/Button.types.ts
+++ b/client/components/Button/Button.types.ts
@@ -9,15 +9,27 @@ type buttonColorType =
 
 type buttonVariantType = 'contained' | 'outlined' | 'text';
 
+type buttonTypeType = 'button' | 'submit' | 'reset';
+
 export default interface ButtonProps {
   /** The button text */
   label: string;
+
   /** The button colour */
   color?: buttonColorType;
+
   /** The variant of the button */
   variant?: buttonVariantType;
+
   /** If true, the button is disabled */
   disabled?: boolean;
+
   /** If true, the button takes the entire width of the container */
   fullWidth?: boolean;
+
+  /** Specifies the type of button, e.g. a clickable button, a submit button to submit form-data, a reset button to reset form-data */
+  type?: buttonTypeType;
+
+  /** The system prop that allows defining system overrides as well as additional CSS styles. */
+  sx?: object;
 }

--- a/client/components/Checkbox/Checkbox.types.ts
+++ b/client/components/Checkbox/Checkbox.types.ts
@@ -10,13 +10,15 @@ type checkboxColorType =
 type checkboxSizeType = 'medium' | 'small';
 
 export default interface CheckboxProps {
+  /** The checkbox label text */
+  label: string;
+
   /** If true, the component is checked. */
   checked?: boolean;
 
   /** Callback fired when the state is changed. */
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  /** The checkbox label text */
-  label: string;
+
   /** The color of the component. */
   color?: checkboxColorType;
 

--- a/client/components/LoginForm/LoginForm.tsx
+++ b/client/components/LoginForm/LoginForm.tsx
@@ -1,0 +1,110 @@
+import * as React from 'react';
+import Avatar from '../Avatar/Avatar';
+import Button from '../Button/Button';
+import TextField from '../TextField/TextField';
+import Checkbox from '../Checkbox/Checkbox';
+import Grid from '../Grid/Grid';
+import Box from '../Box/Box';
+import Typography from '../Typography/Typography';
+import Container from '../Container/Container';
+
+import Link from '@mui/material/Link';
+
+export default function LoginForm() {
+  // on submit just print the email and password to the console for now
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const data = new FormData(event.currentTarget);
+    console.log({
+      email: data.get('email'),
+      password: data.get('password'),
+    });
+  };
+
+  return (
+    <Container
+      component="main"
+      maxWidth="xs"
+    >
+      <Box
+        sx={{
+          marginTop: 8,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          boxShadow: 'rgba(149, 157, 165, 0.2) 0px 8px 24px',
+          p: 2,
+        }}
+        component="div"
+      >
+        <Avatar
+          src="https://i0.wp.com/sbcf.fr/wp-content/uploads/2018/03/sbcf-default-avatar.png?ssl=1"
+          alt="Default avatar image"
+          sx={{ m: 1, bgcolor: 'secondary.main' }}
+        />
+        <Typography
+          component="h1"
+          variant="h5"
+        >
+          Sign in
+        </Typography>
+        <Box
+          component="form"
+          onSubmit={handleSubmit}
+          sx={{ m: 2 }}
+        >
+          <TextField
+            required
+            fullWidth
+            label="Email Address"
+            type="email"
+            name="email"
+            id="email"
+            sx={{ pb: 1 }}
+          />
+          <TextField
+            required
+            fullWidth
+            label="Password"
+            type="password"
+            name="password"
+            id="password"
+            sx={{ pb: 1 }}
+          />
+          <Checkbox label="Remember me" />
+          <Button
+            fullWidth
+            color="primary"
+            variant="contained"
+            label="Sign In"
+            type="submit"
+            sx={{ mb: 1, mt: 1 }}
+          />
+          <Grid container>
+            <Grid
+              item
+              xs
+            >
+              <Link
+                href="#"
+                variant="body2"
+              >
+                Forgot password?
+              </Link>
+            </Grid>
+            <Grid item>
+              {/** NOTE: currently sends user back to home page */}
+              <Link
+                href="/"
+                variant="body2"
+              >
+                {"Don't have an account? Sign up"}
+              </Link>
+            </Grid>
+          </Grid>
+        </Box>
+      </Box>
+    </Container>
+  );
+}

--- a/client/components/LoginForm/LoginForm.tsx
+++ b/client/components/LoginForm/LoginForm.tsx
@@ -26,6 +26,9 @@ export default function LoginForm() {
     <Container
       component="main"
       maxWidth="xs"
+      sx={{
+        marginTop: 30,
+      }}
     >
       <Box
         sx={{

--- a/client/components/LoginForm/LoginForm.tsx
+++ b/client/components/LoginForm/LoginForm.tsx
@@ -37,6 +37,7 @@ export default function LoginForm() {
           flexDirection: 'column',
           alignItems: 'center',
           boxShadow: 'rgba(149, 157, 165, 0.2) 0px 8px 24px',
+          borderRadius: 2,
           p: 2,
         }}
         component="div"

--- a/client/components/LoginForm/LoginForm.tsx
+++ b/client/components/LoginForm/LoginForm.tsx
@@ -11,15 +11,13 @@ import Container from '../Container/Container';
 import Link from 'next/link';
 
 export default function LoginForm() {
-  // on submit just print the email and password to the console for now
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
     const data = new FormData(event.currentTarget);
-    console.log({
-      email: data.get('email'),
-      password: data.get('password'),
-    });
+    {
+      /** NOTE: call to db and verification of credentials will be needed here. To access the input, use `data.get('email')` and `data.get('password')` */
+    }
   };
 
   return (
@@ -90,7 +88,7 @@ export default function LoginForm() {
               item
               xs
             >
-              {/** NOTE: currently sends user back to home page */}
+              {/** NOTE: currently sends user back to home page - needs to be replaced by relevant link */}
               <Typography
                 component="p"
                 variant="body2"
@@ -99,7 +97,7 @@ export default function LoginForm() {
               </Typography>
             </Grid>
             <Grid item>
-              {/** NOTE: currently sends user back to home page */}
+              {/** NOTE: currently sends user back to home page - needs to be replaced by relevant link*/}
               <Typography
                 component="p"
                 variant="body2"

--- a/client/components/TextField/TextField.tsx
+++ b/client/components/TextField/TextField.tsx
@@ -10,6 +10,11 @@ export default function TextField({
   fullWidth,
   type,
   required,
+  name,
+  id,
+  autoFocus,
+  autoComplete,
+  sx,
 }: TextFieldProps) {
   return (
     <MUITextField
@@ -20,6 +25,11 @@ export default function TextField({
       fullWidth={fullWidth}
       type={type}
       required={required}
+      name={name}
+      id={id}
+      autoFocus={autoFocus}
+      autoComplete={autoComplete}
+      sx={sx}
     ></MUITextField>
   );
 }

--- a/client/components/TextField/TextField.types.ts
+++ b/client/components/TextField/TextField.types.ts
@@ -3,16 +3,37 @@ type textfieldVariantType = 'filled' | 'outlined' | 'standard';
 export default interface TextFieldProps {
   /** The text field text */
   label: string;
+
   /** The variant of the text field */
   variant?: textfieldVariantType;
+
   /** If true, the text field is disabled */
   disabled?: boolean;
+
   /** If true, the label is displayed in an error state */
   error?: boolean;
+
   /** If true, the text field takes the entire width of the container */
   fullWidth?: boolean;
+
   /** The type of the text field - must be a valid HTML5 input type e.g 'email',  */
   type?: string;
+
   /** If true, the label is displayed as required and the input is required */
   required?: boolean;
+
+  /** Name attribute of the input element. (Used to access the data from DOM element) */
+  name?: string;
+
+  /** The id of the input element. Use this prop to make label accessible for screen readers. */
+  id?: string;
+
+  /** If true, the input element is focused during the first mount. */
+  autoFocus?: boolean;
+
+  /** This prop helps users to fill forms faster, especially on mobile devices. */
+  autoComplete?: string;
+
+  /** The system prop that allows defining system overrides as well as additional CSS styles. */
+  sx?: object;
 }

--- a/client/pages/_app.tsx
+++ b/client/pages/_app.tsx
@@ -1,4 +1,5 @@
 import type { AppProps } from 'next/app';
+import Head from 'next/head';
 
 import * as React from 'react';
 import ReactDOM from 'react-dom';
@@ -8,6 +9,21 @@ import theme from '../theme/theme';
 function MyApp({ Component, pageProps }: AppProps) {
   return (
     <ThemeProvider theme={theme}>
+      <Head>
+        <title>Home App</title>
+        <link
+          rel="preconnect"
+          href="https://fonts.googleapis.com"
+        />
+        <link
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+        />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Lato:wght@300&display=swap"
+          rel="stylesheet"
+        />
+      </Head>
       <Component {...pageProps} />
     </ThemeProvider>
   );

--- a/client/pages/index.tsx
+++ b/client/pages/index.tsx
@@ -51,6 +51,7 @@ const Home: NextPage = () => {
             flexDirection: 'column',
             alignItems: 'center',
           }}
+          component="span"
         >
           <Grid
             container

--- a/client/pages/login.tsx
+++ b/client/pages/login.tsx
@@ -1,0 +1,8 @@
+import type { NextPage } from 'next';
+import LoginForm from '../components/LoginForm/LoginForm';
+
+const Login: NextPage = () => {
+  return <LoginForm></LoginForm>;
+};
+
+export default Login;

--- a/client/theme/theme.ts
+++ b/client/theme/theme.ts
@@ -6,11 +6,14 @@ import { ThemeProvider, createTheme } from '@mui/material/styles';
 const theme = createTheme({
   palette: {
     primary: {
-      main: blue[500],
+      main: '#3b8cd9',
     },
     secondary: {
-      main: red[500],
+      main: '#ffa51f',
     },
+  },
+  typography: {
+    fontFamily: `'Lato', sans-serif`,
   },
   components: {
     MuiButton: {

--- a/client/theme/theme.ts
+++ b/client/theme/theme.ts
@@ -12,6 +12,7 @@ const theme = createTheme({
       main: '#ffa51f',
     },
   },
+  spacing: 8,
   typography: {
     fontFamily: `'Lato', sans-serif`,
   },


### PR DESCRIPTION
- Built `LoginForm` from our atoms and molecules such as textfield, button, checkbox etc
- Imported `LoginForm` as a component into the page `login.tsx`
- Added prop definitions to the MUI components where necessary
- Expanded theme with spacing, typography and colour palette

Note: Haven't used a template for the layout yet (e.g. grid system for the page) as we don't have wireframes from designers. This is just a skeleton page to use as a starting point

<img width="885" alt="Screenshot 2022-07-19 at 10 26 02" src="https://user-images.githubusercontent.com/59081115/179716839-2588d0c0-50d2-4612-9563-274f2ad6d6cb.png">

